### PR TITLE
Refactored core and config package responsibilities to be cleaner.

### DIFF
--- a/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-aws/src/main/java/org/springframework/cloud/vault/config/aws/VaultConfigAwsBootstrapConfiguration.java
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.vault.config.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessorFactory;
 import org.springframework.cloud.vault.VaultSecretBackend;
-import org.springframework.cloud.vault.config.SecureBackendAccessorFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;

--- a/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/AwsSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-aws/src/test/java/org/springframework/cloud/vault/config/aws/AwsSecretIntegrationTests.java
@@ -19,21 +19,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.Settings;
 import org.springframework.util.StringUtils;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.aws.VaultConfigAwsBootstrapConfiguration.AwsSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.aws.VaultConfigAwsBootstrapConfiguration.AwsSecureBackendAccessorFactory.forAws;
 
 /**
  * Integration tests for {@link VaultClient} using the aws secret backend. This test
@@ -82,8 +82,8 @@ public class AwsSecretIntegrationTests extends AbstractIntegrationTests {
 		prepare().write(String.format("%s/roles/%s", aws.getBackend(), aws.getRole()),
 				Collections.singletonMap("arn", ARN));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-consul/src/main/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-consul/src/main/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulBootstrapConfiguration.java
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.vault.config.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessorFactory;
 import org.springframework.cloud.vault.VaultSecretBackend;
-import org.springframework.cloud.vault.config.SecureBackendAccessorFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;

--- a/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/ConsulSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/ConsulSecretIntegrationTests.java
@@ -20,13 +20,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.Settings;
 import org.springframework.core.ParameterizedTypeReference;
@@ -36,12 +39,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Base64Utils;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.consul.VaultConfigConsulBootstrapConfiguration.ConsulSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.consul.VaultConfigConsulBootstrapConfiguration.ConsulSecureBackendAccessorFactory.forConsul;
 
 /**
  * Integration tests for {@link VaultClient} using the consul secret backend. This test
@@ -106,8 +106,8 @@ public class ConsulSecretIntegrationTests extends AbstractIntegrationTests {
 				Collections.singletonMap("policy",
 						Base64Utils.encodeToString(POLICY.getBytes())));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulTests.java
+++ b/spring-cloud-vault-config-consul/src/test/java/org/springframework/cloud/vault/config/consul/VaultConfigConsulTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.vault.config.consul;
 
-import static org.assertj.core.api.Java6Assertions.*;
-import static org.junit.Assume.*;
-
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -31,7 +28,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
@@ -45,18 +41,21 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.codec.Base64;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Integration tests using the consul secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
  * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
- * 
+ *
  * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = VaultConfigConsulTests.TestApplication.class)
 @IntegrationTest({ "spring.cloud.vault.consul.enabled=true",
-		"spring.cloud.vault.consul.role=readonly" })
+"spring.cloud.vault.consul.role=readonly" })
 public class VaultConfigConsulTests {
 
 	private final static String CONSUL_HOST = "localhost";

--- a/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-databases/src/main/java/org/springframework/cloud/vault/config/databases/VaultConfigDatabaseBootstrapConfiguration.java
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.vault.config.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessorFactory;
 import org.springframework.cloud.vault.VaultSecretBackend;
-import org.springframework.cloud.vault.config.SecureBackendAccessorFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/CassandraSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/CassandraSecretIntegrationTests.java
@@ -20,21 +20,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.Settings;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.forDatabase;
 
 /**
  * Integration tests for {@link VaultClient} using the cassandra secret backend. This test
@@ -84,13 +84,13 @@ public class CassandraSecretIntegrationTests extends AbstractIntegrationTests {
 				connection);
 
 		prepare()
-				.write(String.format("%s/roles/%s", cassandra.getBackend(),
-						cassandra.getRole()),
-						Collections.singletonMap("creation_cql",
-								CREATE_USER_AND_GRANT_CQL));
+		.write(String.format("%s/roles/%s", cassandra.getBackend(),
+				cassandra.getRole()),
+				Collections.singletonMap("creation_cql",
+						CREATE_USER_AND_GRANT_CQL));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/MySqlSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/MySqlSecretIntegrationTests.java
@@ -19,21 +19,21 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.Settings;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.forDatabase;
 
 /**
  * Integration tests for {@link VaultClient} using the mysql secret backend. This test
@@ -78,8 +78,8 @@ public class MySqlSecretIntegrationTests extends AbstractIntegrationTests {
 				String.format("%s/roles/%s", mySql.getBackend(), mySql.getRole()),
 				Collections.singletonMap("sql", CREATE_USER_AND_GRANT_SQL));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/PostgreSqlSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/PostgreSqlSecretIntegrationTests.java
@@ -19,21 +19,21 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.Settings;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.databases.VaultConfigDatabaseBootstrapConfiguration.DatabaseSecureBackendAccessorFactory.forDatabase;
 
 /**
  * Integration tests for {@link VaultClient} using the postgresql secret backend. This
@@ -83,8 +83,8 @@ public class PostgreSqlSecretIntegrationTests extends AbstractIntegrationTests {
 						postgreSql.getRole()),
 				Collections.singletonMap("sql", CREATE_USER_AND_GRANT_SQL));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCassandraTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigCassandraTests.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import com.datastax.driver.core.Session;
 
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
@@ -37,21 +38,20 @@ import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.VaultRule;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.PlainTextAuthProvider;
-import com.datastax.driver.core.Session;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Integration tests using the cassandra secret backend. In case this test should fail because of SSL make sure you run
  * the test within the spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is referenced with
  * {@code ../work/keystore.jks}.
- * 
+ *
  * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = VaultConfigCassandraTests.TestApplication.class)
 @IntegrationTest({ "spring.cloud.vault.cassandra.enabled=true",
-		"spring.cloud.vault.cassandra.role=readonly" })
+"spring.cloud.vault.cassandra.role=readonly" })
 public class VaultConfigCassandraTests {
 
 	private final static String CASSANDRA_HOST = "localhost";

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigMySqlTests.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.cloud.vault.config.databases;
 
-import static org.junit.Assume.*;
-
 import java.net.InetSocketAddress;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -37,18 +35,20 @@ import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.VaultRule;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Integration tests using the mysql secret backend. In case this test should fail because of SSL make sure you run the
  * test within the spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is referenced with
  * {@code ../work/keystore.jks}.
- * 
+ *
  * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = VaultConfigMySqlTests.TestApplication.class)
 @IntegrationTest({ "spring.cloud.vault.mysql.enabled=true",
-		"spring.cloud.vault.mysql.role=readonly",
-		"spring.datasource.url=jdbc:mysql://localhost:3306/mysql?useSSL=false" })
+	"spring.cloud.vault.mysql.role=readonly",
+"spring.datasource.url=jdbc:mysql://localhost:3306/mysql?useSSL=false" })
 public class VaultConfigMySqlTests {
 
 	private final static int MYSQL_PORT = 3306;

--- a/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigPostgreSqlTests.java
+++ b/spring-cloud-vault-config-databases/src/test/java/org/springframework/cloud/vault/config/databases/VaultConfigPostgreSqlTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.vault.config.databases;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-
 import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -40,17 +37,20 @@ import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.VaultRule;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Integration tests using the postgresql secret backend. In case this test should fail because of SSL make sure you run
  * the test within the spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is referenced with
  * {@code ../work/keystore.jks}.
- * 
+ *
  * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = VaultConfigPostgreSqlTests.TestApplication.class)
 @IntegrationTest({ "spring.cloud.vault.postgresql.enabled=true",
-		"spring.cloud.vault.postgresql.role=readonly", "spring.datasource.url=jdbc:postgresql://localhost:5432/postgres?ssl=false" })
+	"spring.cloud.vault.postgresql.role=readonly", "spring.datasource.url=jdbc:postgresql://localhost:5432/postgres?ssl=false" })
 public class VaultConfigPostgreSqlTests {
 
 	private final static String POSTGRES_HOST = "localhost";

--- a/spring-cloud-vault-config-rabbitmq/src/main/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqBootstrapConfiguration.java
+++ b/spring-cloud-vault-config-rabbitmq/src/main/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqBootstrapConfiguration.java
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.vault.config.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessor;
+import org.springframework.cloud.vault.SecureBackendAccessorFactory;
 import org.springframework.cloud.vault.VaultSecretBackend;
-import org.springframework.cloud.vault.config.SecureBackendAccessorFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;

--- a/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/RabbitMqSecretIntegrationTests.java
+++ b/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/RabbitMqSecretIntegrationTests.java
@@ -20,21 +20,21 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.config.VaultConfigOperations;
-import org.springframework.cloud.vault.config.VaultTemplate;
+import org.springframework.cloud.vault.config.VaultConfigTemplate;
 import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.Settings;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assume.*;
-import static org.springframework.cloud.vault.config.rabbitmq.VaultConfigRabbitMqBootstrapConfiguration.RabbitMqSecureBackendAccessorFactory.*;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.springframework.cloud.vault.config.rabbitmq.VaultConfigRabbitMqBootstrapConfiguration.RabbitMqSecureBackendAccessorFactory.forRabbitMq;
 
 /**
  * Integration tests for {@link VaultClient} using the rabbitmq secret backend. This test
@@ -89,8 +89,8 @@ public class RabbitMqSecretIntegrationTests extends AbstractIntegrationTests {
 				String.format("%s/roles/%s", rabbitmq.getBackend(), rabbitmq.getRole()),
 				Collections.singletonMap("vhosts", VHOSTS_ROLE));
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate vaultTemplate = new VaultTemplate(vaultProperties, prepare().newVaultClient(), ClientAuthentication.token(vaultProperties));
+		configOperations = new VaultConfigTemplate(vaultTemplate, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
+++ b/spring-cloud-vault-config-rabbitmq/src/test/java/org/springframework/cloud/vault/config/rabbitmq/VaultConfigRabbitMqTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.vault.config.rabbitmq;
 
-import static org.junit.Assume.*;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
@@ -36,23 +38,21 @@ import org.springframework.cloud.vault.util.CanConnect;
 import org.springframework.cloud.vault.util.VaultRule;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
-import com.rabbitmq.client.ConnectionFactory;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Integration tests using the rabbitmq secret backend. In case this test should fail
  * because of SSL make sure you run the test within the
  * spring-cloud-vault-config/spring-cloud-vault-config directory as the keystore is
  * referenced with {@code ../work/keystore.jks}.
- * 
+ *
  * @author Mark Paluch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = VaultConfigRabbitMqTests.TestApplication.class)
 @IntegrationTest({ "spring.cloud.vault.rabbitmq.enabled=true",
-		"spring.cloud.vault.rabbitmq.role=readonly",
-		"spring.rabbitmq.address=localhost" })
+	"spring.cloud.vault.rabbitmq.role=readonly",
+"spring.rabbitmq.address=localhost" })
 public class VaultConfigRabbitMqTests {
 
 	private final static int RABBITMQ_HTTP_MANAGEMENT_PORT = 15672;

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigOperations.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigOperations.java
@@ -15,12 +15,10 @@
  */
 package org.springframework.cloud.vault.config;
 
-import java.net.URI;
 import java.util.Map;
 
-import org.springframework.cloud.vault.VaultClientResponse;
+import org.springframework.cloud.vault.SecureBackendAccessor;
 import org.springframework.cloud.vault.VaultProperties;
-import org.springframework.cloud.vault.VaultToken;
 
 /**
  * Interface that specified a basic set of Vault operations, implemented by

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigTemplate.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigTemplate.java
@@ -15,26 +15,27 @@
  */
 package org.springframework.cloud.vault.config;
 
+import lombok.extern.apachecommons.CommonsLog;
+
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
 import org.springframework.cloud.vault.ClientAuthentication;
+import org.springframework.cloud.vault.SecureBackendAccessor;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultClientResponse;
+import org.springframework.cloud.vault.VaultOperations;
+import org.springframework.cloud.vault.VaultOperations.SessionCallback;
+import org.springframework.cloud.vault.VaultOperations.VaultSession;
 import org.springframework.cloud.vault.VaultProperties;
-import org.springframework.cloud.vault.config.VaultOperations.SessionCallback;
-import org.springframework.cloud.vault.config.VaultOperations.VaultSession;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
 
-import lombok.extern.apachecommons.CommonsLog;
-
-import org.apache.commons.logging.Log;
-
 /**
  * Central class to retrieve configuration from Vault.
- * 
+ *
  * @author Mark Paluch
  * @see VaultClient
  * @see ClientAuthentication
@@ -67,7 +68,7 @@ public class VaultConfigTemplate implements VaultConfigOperations {
 
 		Assert.notNull(secureBackendAccessor, "SecureBackendAccessor must not be null!");
 
-		VaultClientResponse response = vaultOperations.doWithVault("{backend}/{key}",
+		VaultClientResponse response = (VaultClientResponse) vaultOperations.doWithVault("{backend}/{key}",
 				secureBackendAccessor.variables(), callback);
 
 		if (response.getStatusCode() == HttpStatus.OK) {

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultHealthIndicator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultHealthIndicator.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.cloud.vault.VaultHealthResponse;
+import org.springframework.cloud.vault.VaultTemplate;
 
 /**
  * @author Stuart Ingram

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySource.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySource.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.cloud.vault.SecureBackendAccessor;
 import org.springframework.cloud.vault.VaultProperties;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.util.Assert;

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.vault.config;
 
+import static org.springframework.cloud.vault.SecureBackendAccessors.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -23,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.cloud.vault.SecureBackendAccessor;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
 import org.springframework.core.env.CompositePropertySource;
@@ -31,8 +34,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import static org.springframework.cloud.vault.config.SecureBackendAccessors.*;
 
 /**
  * {@link PropertySourceLocator} using {@link VaultClient}.

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/AppIdAuthenticationIntegrationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/AppIdAuthenticationIntegrationTests.java
@@ -15,15 +15,14 @@
  */
 package org.springframework.cloud.vault.config;
 
+import org.junit.Before;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.IpAddressUserId;
-import org.springframework.cloud.vault.TestRestTemplateFactory;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties.AppIdProperties;
 import org.springframework.cloud.vault.VaultProperties.AuthenticationMethod;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.util.Settings;
-
-import org.junit.Before;
 
 /**
  * Integration tests for {@link VaultClient} using {@link AuthenticationMethod#APPID}.
@@ -32,6 +31,7 @@ import org.junit.Before;
  */
 public class AppIdAuthenticationIntegrationTests extends GenericSecretIntegrationTests {
 
+	@Override
 	@Before
 	public void setUp() throws Exception {
 
@@ -58,9 +58,10 @@ public class AppIdAuthenticationIntegrationTests extends GenericSecretIntegratio
 		ClientAuthentication clientAuthentication = ClientAuthentication.appId(
 				vaultProperties, vaultClient, userIdMechanism);
 
-		configOperations = new VaultTemplate(vaultProperties,
+		VaultTemplate template = new VaultTemplate(vaultProperties,
 				vaultClient,
-				clientAuthentication).opsForConfig();
+				clientAuthentication);
+		configOperations = new VaultConfigTemplate(template, vaultProperties);
 	}
 
 	private AppIdProperties configureAppIdProperties() {

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/GenericSecretIntegrationTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/GenericSecretIntegrationTests.java
@@ -15,20 +15,20 @@
  */
 package org.springframework.cloud.vault.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.vault.SecureBackendAccessors.generic;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.cloud.vault.AbstractIntegrationTests;
 import org.springframework.cloud.vault.ClientAuthentication;
 import org.springframework.cloud.vault.VaultClient;
 import org.springframework.cloud.vault.VaultProperties;
+import org.springframework.cloud.vault.VaultTemplate;
 import org.springframework.cloud.vault.util.Settings;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.cloud.vault.config.SecureBackendAccessors.*;
-
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Integration tests for {@link VaultClient} using the generic secret backend.
@@ -44,10 +44,13 @@ public class GenericSecretIntegrationTests extends AbstractIntegrationTests {
 	public void setUp() throws Exception {
 
 		vaultProperties.setFailFast(false);
-		prepare().writeSecret("app-name", (Map) createData());
+		prepare().writeSecret("app-name", createData());
 
-		configOperations = new VaultTemplate(vaultProperties, prepare().newVaultClient(),
-				ClientAuthentication.token(vaultProperties)).opsForConfig();
+		VaultTemplate template = new VaultTemplate(vaultProperties,
+				prepare().newVaultClient(),
+				ClientAuthentication.token(vaultProperties));
+
+		configOperations = new VaultConfigTemplate(template, vaultProperties);
 	}
 
 	@Test

--- a/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultHealthIndicatorUnitTests.java
+++ b/spring-cloud-vault-config/src/test/java/org/springframework/cloud/vault/config/VaultHealthIndicatorUnitTests.java
@@ -27,6 +27,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.cloud.vault.VaultHealthResponse;
+import org.springframework.cloud.vault.VaultTemplate;
 
 /**
  * @author Mark Paluch

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessor.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import java.util.Map;
 

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessorFactory.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessorFactory.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.vault.config;
-
-import org.springframework.cloud.vault.VaultSecretBackend;
+package org.springframework.cloud.vault;
 
 /**
  * Factory to convert {@link VaultSecretBackend} instance to a

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessors.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendAccessors.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  */
-class SecureBackendAccessors {
+public class SecureBackendAccessors {
 
 	/**
 	 * Creates a {@link SecureBackendAccessor} for the {@code generic} secure backend.

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendFactories.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/SecureBackendFactories.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import lombok.extern.apachecommons.CommonsLog;
-import org.springframework.cloud.vault.VaultSecretBackend;
 
 /**
  * @author Mark Paluch

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultOperations.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultOperations.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import java.net.URI;
 import java.util.Map;
-
-import org.springframework.cloud.vault.VaultClientResponse;
-import org.springframework.cloud.vault.VaultHealthResponse;
 
 /**
  * Interface that specified a basic set of Vault operations, implemented by
@@ -28,11 +25,6 @@ import org.springframework.cloud.vault.VaultHealthResponse;
  * @author Mark Paluch
  */
 public interface VaultOperations {
-
-	/**
-	 * @return the operations interface to interact with Vault configuration data.
-	 */
-	VaultConfigOperations opsForConfig();
 
 	/**
 	 * Executes a Vault {@link SessionCallback}. Allows to interact with Vault in an

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultState.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultState.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import lombok.Data;
-import org.springframework.cloud.vault.VaultToken;
 
 /**
  * State of the Vault client.

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultTemplate.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultTemplate.java
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.vault.config;
+package org.springframework.cloud.vault;
 
 import java.net.URI;
 import java.util.Map;
 
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cloud.vault.ClientAuthentication;
-import org.springframework.cloud.vault.VaultClient;
-import org.springframework.cloud.vault.VaultClientResponse;
-import org.springframework.cloud.vault.VaultHealthResponse;
-import org.springframework.cloud.vault.VaultProperties;
-import org.springframework.cloud.vault.VaultToken;
 import org.springframework.util.Assert;
 
 /**
@@ -90,11 +84,6 @@ public class VaultTemplate implements InitializingBean, VaultOperations {
 		}
 
 		return vaultState.getToken();
-	}
-
-	@Override
-	public VaultConfigOperations opsForConfig() {
-		return new VaultConfigTemplate(this, properties);
 	}
 
 	@Override


### PR DESCRIPTION
I took a first stab at the refactoring previously discussed.  All 'core' vault communication, authentication etc has been migrated from the 'config' package to the 'core' package.  Essentially this is the VaultTemplate class and it's dependencies.  This necessitated the decoupling of the VaultTemplate from VaultConfigTemplate.

Left in the 'config' package are the configuration/property specific classes and HealthIndicator behavior as this is really the front line package for interfacing with a spring-boot application.

I do apologize for some of the unnecessary import ordering, I have tried to best match the conventions already found in the code but found some to be inconsistent and in some cases eclipse was not behaving as expected.  I'm using Eclipse Mars, if you could export the import ordering for the project I'd be happy to use and reorder the imports accordingly.