### PR TITLE
Configurable PriorityOrdered implementation to the VaultPropertySourc…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -180,6 +180,8 @@ spring.cloud.vault:
     scheme: https
     connection-timeout: 5000
     read-timeout: 15000
+    config:
+        order: -10
 ----
 
 * `host` sets the hostname of the Vault host. The host name will be used

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
@@ -29,6 +29,7 @@ import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -40,7 +41,7 @@ import static org.springframework.cloud.vault.config.SecureBackendAccessors.*;
  * @author Spencer Gibb
  * @author Mark Paluch
  */
-class VaultPropertySourceLocator implements PropertySourceLocator {
+class VaultPropertySourceLocator implements PropertySourceLocator, PriorityOrdered {
 
 	private final VaultConfigOperations operations;
 	private final VaultProperties properties;
@@ -83,6 +84,11 @@ class VaultPropertySourceLocator implements PropertySourceLocator {
 			return propertySource;
 		}
 		return null;
+	}
+
+	@Override
+	public int getOrder() {
+		return properties.getConfig().getOrder();
 	}
 
 	private List<String> buildContexts(ConfigurableEnvironment env) {

--- a/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultProperties.java
+++ b/spring-cloud-vault-core/src/main/java/org/springframework/cloud/vault/VaultProperties.java
@@ -78,6 +78,8 @@ public class VaultProperties {
 
 	private Ssl ssl = new Ssl();
 
+	private Config config = new Config();
+
 	/**
 	 * Application name for AppId authentication.
 	 */
@@ -175,6 +177,15 @@ public class VaultProperties {
 		 */
 		@NotEmpty
 		private String certAuthPath = "cert";
+	}
+
+	@Data
+	public static class Config {
+		/**
+		 * Used to force a PropertySourceLocator ordering.
+		 * This is useful to use Vault as an override on consul properties;
+		 */
+		private int order = 0;
 	}
 
 	public enum AuthenticationMethod {


### PR DESCRIPTION
This PR adds PriorityOrdered interface to the VaultPropertySourceLocator class.

This allows to choose the order in which overriden properties are managed. In our use case, we were looking for a way to Vault property to have higher priority than Consul. 

@mp911de As requested, here is the feature pull request. Should be useful for others.